### PR TITLE
inital project structure

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,12 @@
+# Credits
+
+## Development Lead
+
+- Max Resnick [maxres-fr](https://github.com/maxres-fr)
+- Lee Baines  [lee-bains](https://github.com/lee-baines)
+- Jhonattan Castillo [jrcast](https://github.com/jrcast)
+- Warren Strange [wstrange](https://google.com/wstrang)
+
+## Contributors
+
+None yet. Why not be the first?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing
+
+Contributions are welcome, and they are greatly appreciated! Every little bit helps, and credit will always be given.
+
+You can contribute in many ways:
+
+## Types of Contributions
+
+### Report Bugs
+
+Report bugs at https://github.com/ForgeRock/forgeops-cli/issues.
+
+If you are reporting a bug, please include:
+
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
+
+### Fix Bugs
+
+Look through the GitHub issues for bugs. Anything tagged with "bug"
+is open to whoever wants to implement it.
+
+### Implement Features
+
+Look through the GitHub issues for features. Anything tagged with "feature"
+is open to whoever wants to implement it.
+
+### Write Documentation
+
+forgeops-cli could always use more documentation, whether as part of the
+official forgeops-cli docs, in docstrings, or even on the web in blog posts,
+articles, and such.
+
+### Submit Feedback
+
+The best way to send feedback is to file an issue at https://github.com/ForgeRock/forgeops-cli/issues.
+
+If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that contributions
+  are welcome :)
+
+## Get Started!
+
+Ready to contribute? Here's how to set up `forgeops-cli` for local development.
+
+1. Fork the `forgeops-cli` repo on GitHub.
+2. Clone your fork locally::
+```bash
+    $ git clone git@github.com:your_name_here/forgeops-cli.git
+```
+3. Create a branch for local development::
+```bash
+    $ git checkout -b name-of-your-bugfix-or-feature
+```
+   Now you can make your changes locally.
+
+4. When you're done making changes, check that your changes pass the tests::
+```bash
+    $ make test
+```
+6. Commit your changes and push your branch to GitHub::
+```bash
+    $ git add .
+    $ git commit -m "Your detailed description of your changes."
+    $ git push origin name-of-your-bugfix-or-feature
+```
+7. Submit a pull request through the GitHub website.
+
+Pull Request Guidelines
+-----------------------
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include tests.
+2. If the pull request adds functionality, the docs should be updated. Put
+   your new functionality into a function with a docstring, and add the
+   feature to the list in README.md.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var cfgFile string
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "forgeops",
+	Short: "forgeops is a tool for managing ForgeRock platform deployments",
+	Long: `
+	This is some long help information
+	`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/ForgeRock/forgeops-cli/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of generated code example",
+	Long:  `All software has versions. This is generated code example`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Build Date:", version.BuildDate)
+		fmt.Println("Git Commit:", version.GitCommit)
+		fmt.Println("Version:", version.Version)
+		fmt.Println("Go Version:", version.GoVersion)
+		fmt.Println("OS / Arch:", version.OsArch)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/ForgeRock/forgeops-cli
+
+go 1.14
+
+require (
+	github.com/spf13/cobra v0.0.3
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
+github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/ForgeRock/forgeops-cli/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,21 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// GitCommit returns the git commit that was compiled. This will be filled in by the compiler.
+var GitCommit string
+
+// Version returns the main version number that is being run at the moment.
+const Version = "0.1.0"
+
+// BuildDate returns the date the binary was built
+var BuildDate = ""
+
+// GoVersion returns the version of the go runtime used to compile the binary
+var GoVersion = runtime.Version()
+
+// OsArch returns the os and arch used to build the binary
+var OsArch = fmt.Sprintf("%s %s", runtime.GOOS, runtime.GOARCH)


### PR DESCRIPTION
Here's a quick cut of a project layout. I generated and changed from "cookiecutter"  and trimmed it way down. I'll do another PR for builds and other things. The "cobra" spf setup is pretty much the "quick start". I wanted to get some sort of structure up so @lee-baines can start and then we all can start.

`make` works and then `./bin/forgeops version` works. 