### PR TITLE
Add custom FQDN support to the CDQ deployment

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -9,6 +9,7 @@ import (
 
 // cmd globals config
 var applyFlags *genericclioptions.ConfigFlags
+var fqdn string
 
 var quickstart = &cobra.Command{
 	Use:     "quickstart",
@@ -26,9 +27,12 @@ var quickstart = &cobra.Command{
       forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci
       
       # Deploy the CDQ in a given namespace.
-      forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace`,
+      forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace
+      
+      # Deploy the CDQ with a custom FQDN.
+      forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace --fqdn demo.customdomain.com`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := apply.Quickstart(clientFactory, tag)
+		err := apply.Quickstart(clientFactory, tag, fqdn)
 		return err
 	},
 	SilenceUsage:      true,
@@ -92,7 +96,10 @@ var applyCmd = &cobra.Command{
     forgeops apply sa
 
     # Deploy the CDQ in a given namespace.
-    forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace`,
+    forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace
+    
+    # Deploy the CDQ with a custom FQDN.
+    forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace --fqdn demo.customdomain.com`,
 	// Configure Client Mgr for all subcommands
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		clientFactory = factory.NewFactory(applyFlags)
@@ -106,7 +113,8 @@ func init() {
 	applyFlags = initK8sFlags(applyCmd.PersistentFlags())
 
 	// Apply command-specific flags
-	applyCmd.PersistentFlags().StringVarP(&tag, "tag", "t", "", "Release tag  of the component to be deployed")
+	applyCmd.PersistentFlags().StringVarP(&tag, "tag", "t", "", "Release tag  of the component to be deployed (default \"latest\")")
+	quickstart.PersistentFlags().StringVar(&fqdn, "fqdn", "", "FQDN for CDQ deployment. (default \"[NAMESPACE].iam.example.com\")")
 
 	applyCmd.AddCommand(quickstart)
 	applyCmd.AddCommand(secretAgent)

--- a/docs/forgeops_apply.md
+++ b/docs/forgeops_apply.md
@@ -19,6 +19,9 @@ Deploy common platform components
 
     # Deploy the CDQ in a given namespace.
     forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace
+    
+    # Deploy the CDQ with a custom FQDN.
+    forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace --fqdn demo.customdomain.com
 ```
 
 ### Options
@@ -39,7 +42,7 @@ Deploy common platform components
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-  -t, --tag string                     Release tag  of the component to be deployed
+  -t, --tag string                     Release tag  of the component to be deployed (default "latest")
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use

--- a/docs/forgeops_apply_ds.md
+++ b/docs/forgeops_apply_ds.md
@@ -47,7 +47,7 @@ forgeops apply ds [flags]
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-  -t, --tag string                     Release tag  of the component to be deployed
+  -t, --tag string                     Release tag  of the component to be deployed (default "latest")
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use

--- a/docs/forgeops_apply_quickstart.md
+++ b/docs/forgeops_apply_quickstart.md
@@ -25,12 +25,16 @@ forgeops apply quickstart [flags]
       
       # Deploy the CDQ in a given namespace.
       forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace
+      
+      # Deploy the CDQ with a custom FQDN.
+      forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace --fqdn demo.customdomain.com
 ```
 
 ### Options
 
 ```
-  -h, --help   help for quickstart
+      --fqdn string   FQDN for CDQ deployment. (default "[NAMESPACE].iam.example.com")
+  -h, --help          help for quickstart
 ```
 
 ### Options inherited from parent commands
@@ -50,7 +54,7 @@ forgeops apply quickstart [flags]
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-  -t, --tag string                     Release tag  of the component to be deployed
+  -t, --tag string                     Release tag  of the component to be deployed (default "latest")
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use

--- a/docs/forgeops_apply_secret-agent.md
+++ b/docs/forgeops_apply_secret-agent.md
@@ -47,7 +47,7 @@ forgeops apply secret-agent [flags]
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-  -t, --tag string                     Release tag  of the component to be deployed
+  -t, --tag string                     Release tag  of the component to be deployed (default "latest")
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -9,18 +9,21 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 )
 
+// TransformInfoFunc is used to modify the resource.Info
+type TransformInfoFunc func(*resource.Info) (*resource.Info, error)
+
 // Manifest Installs the quickstart in the namespace provided
-func Manifest(clientFactory factory.Factory, path string) error {
+func Manifest(clientFactory factory.Factory, path string, transformFunctions ...TransformInfoFunc) error {
 	k8sCntMgr := k8s.NewK8sClientMgr(clientFactory)
 	infos, err := k8sCntMgr.GetObjectsFromPath(path)
 	if err != nil {
 		return err
 	}
-	return Resources(clientFactory, infos)
+	return Resources(clientFactory, infos, transformFunctions...)
 }
 
 // Resources applies the resources provided
-func Resources(clientFactory factory.Factory, infos []*resource.Info) error {
+func Resources(clientFactory factory.Factory, infos []*resource.Info, transformFunctions ...TransformInfoFunc) error {
 	errs := []error{}
 	k8sCntMgr := k8s.NewK8sClientMgr(clientFactory)
 	cfg, err := k8sCntMgr.GetOverrideFlags()
@@ -29,6 +32,13 @@ func Resources(clientFactory factory.Factory, infos []*resource.Info) error {
 	}
 	if len(infos) == 0 {
 		return fmt.Errorf("no objects found")
+	}
+	for _, tf := range transformFunctions {
+		for _, info := range infos {
+			if _, err := tf(info); err != nil {
+				return err
+			}
+		}
 	}
 	// Iterate through all objects, applying each one.
 	for _, info := range infos {


### PR DESCRIPTION
1. Add custom FQDN support to the CDQ deployment
1. Add `--fqdn` flag to `apply quickstart` cmd
1. Updated `pkg.apply` functions to accept transform functions
1. Expanded quickstart config in preparation for a custom config object
1. Updated `--tag` help text

Closes #35
Closes #36