### PR TITLE
Simplify clientMgr and add support for custom FQDN

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -9,6 +9,7 @@ import (
 
 // cmd globals config
 var applyFlags *genericclioptions.ConfigFlags
+var fqdn string
 
 var quickstart = &cobra.Command{
 	Use:     "quickstart",
@@ -26,9 +27,12 @@ var quickstart = &cobra.Command{
       forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci
       
       # Deploy the CDQ in a given namespace.
-      forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace`,
+      forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace
+      
+      # Deploy the CDQ with a custom FQDN.
+      forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace --fqdn demo.customdomain.com`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := apply.Quickstart(clientFactory, tag)
+		err := apply.Quickstart(clientFactory, tag, fqdn)
 		return err
 	},
 	SilenceUsage:      true,
@@ -92,7 +96,10 @@ var applyCmd = &cobra.Command{
     forgeops apply sa
 
     # Deploy the CDQ in a given namespace.
-    forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace`,
+    forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace
+    
+    # Deploy the CDQ with a custom FQDN.
+    forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace --fqdn demo.customdomain.com`,
 	// Configure Client Mgr for all subcommands
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		clientFactory = factory.NewFactory(applyFlags)
@@ -106,7 +113,8 @@ func init() {
 	applyFlags = initK8sFlags(applyCmd.PersistentFlags())
 
 	// Apply command-specific flags
-	applyCmd.PersistentFlags().StringVarP(&tag, "tag", "t", "", "Release tag  of the component to be deployed")
+	applyCmd.PersistentFlags().StringVarP(&tag, "tag", "t", "", "Release tag  of the component to be deployed (default \"latest\")")
+	quickstart.PersistentFlags().StringVar(&fqdn, "fqdn", "", "FQDN for CDQ deployment. (default \"[NAMESPACE].iam.example.com\")")
 
 	applyCmd.AddCommand(quickstart)
 	applyCmd.AddCommand(secretAgent)

--- a/docs/forgeops_apply.md
+++ b/docs/forgeops_apply.md
@@ -19,6 +19,9 @@ Deploy common platform components
 
     # Deploy the CDQ in a given namespace.
     forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace
+    
+    # Deploy the CDQ with a custom FQDN.
+    forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace --fqdn demo.customdomain.com
 ```
 
 ### Options
@@ -39,7 +42,7 @@ Deploy common platform components
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-  -t, --tag string                     Release tag  of the component to be deployed
+  -t, --tag string                     Release tag  of the component to be deployed (default "latest")
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use

--- a/docs/forgeops_apply_ds.md
+++ b/docs/forgeops_apply_ds.md
@@ -47,7 +47,7 @@ forgeops apply ds [flags]
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-  -t, --tag string                     Release tag  of the component to be deployed
+  -t, --tag string                     Release tag  of the component to be deployed (default "latest")
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use

--- a/docs/forgeops_apply_quickstart.md
+++ b/docs/forgeops_apply_quickstart.md
@@ -25,12 +25,16 @@ forgeops apply quickstart [flags]
       
       # Deploy the CDQ in a given namespace.
       forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace
+      
+      # Deploy the CDQ with a custom FQDN.
+      forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace --fqdn demo.customdomain.com
 ```
 
 ### Options
 
 ```
-  -h, --help   help for quickstart
+      --fqdn string   FQDN for CDQ deployment. (default "[NAMESPACE].iam.example.com")
+  -h, --help          help for quickstart
 ```
 
 ### Options inherited from parent commands
@@ -50,7 +54,7 @@ forgeops apply quickstart [flags]
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-  -t, --tag string                     Release tag  of the component to be deployed
+  -t, --tag string                     Release tag  of the component to be deployed (default "latest")
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use

--- a/docs/forgeops_apply_secret-agent.md
+++ b/docs/forgeops_apply_secret-agent.md
@@ -47,7 +47,7 @@ forgeops apply secret-agent [flags]
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-  -t, --tag string                     Release tag  of the component to be deployed
+  -t, --tag string                     Release tag  of the component to be deployed (default "latest")
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use

--- a/internal/k8s/clientMgr.go
+++ b/internal/k8s/clientMgr.go
@@ -1,14 +1,12 @@
 package k8s
 
 import (
-	"encoding/json"
 	"fmt"
-	"strings"
+	"io"
 
 	"github.com/ForgeRock/forgeops-cli/internal/factory"
 	"github.com/ForgeRock/forgeops-cli/internal/printer"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -31,11 +29,10 @@ type ClientMgr interface {
 	factory.Factory
 	Namespace() (string, error)
 	GetObjectsFromPath(path string) ([]*resource.Info, error)
+	GetObjectsFromStream(reader io.Reader) ([]*resource.Info, error)
 	GetObjectsFromServer(resourceType, name string) ([]*resource.Info, error)
 	ApplyObject(info *resource.Info) error
-	ApplyObjectInOtherNamespace(info *resource.Info, namespace string) error
 	DeleteObject(info *resource.Info) error
-	DeleteObjectFromOtherNamespace(info *resource.Info, namespace string) error
 	WaitForResource(timeoutSecs int, ns, name string, gvr schema.GroupVersionResource) (bool, error)
 	WaitForResourceStatusCondition(timeoutSecs int, ns, name, conditionStr string, gvr schema.GroupVersionResource) (bool, error)
 	WaitForResourceReplicas(timeoutSecs int, ns, name, replicas string, gvr schema.GroupVersionResource) (bool, error)
@@ -92,7 +89,27 @@ func (cmgr clientMgr) GetObjectsFromPath(path string) ([]*resource.Info, error) 
 	return objects, err
 }
 
-// GetObjectsFromServer Obtains objects from the k8s server
+// GetObjectsFromPath Obtains objects from a io.Reader stream
+func (cmgr clientMgr) GetObjectsFromStream(reader io.Reader) ([]*resource.Info, error) {
+	cfg, err := cmgr.GetOverrideFlags()
+	if err != nil {
+		return nil, err
+	}
+
+	builder := cmgr.Builder()
+	r := builder.
+		Unstructured().
+		Schema(NullSchema{}).
+		ContinueOnError().
+		// Use cfg.Namespace in case there's an override. Otherwise default to the ns in the manifest
+		NamespaceParam(*cfg.Namespace).DefaultNamespace().
+		Stream(reader, "stream").
+		Flatten().
+		Do()
+	objects, err := r.Infos()
+	return objects, err
+}
+
 // if no name is provided, this function will return all objects of the given type
 func (cmgr clientMgr) GetObjectsFromServer(resourceType, name string) ([]*resource.Info, error) {
 	ns, err := cmgr.Namespace()
@@ -122,33 +139,21 @@ func (cmgr clientMgr) GetObjectsFromServer(resourceType, name string) ([]*resour
 
 // ApplyObject Applies changes to the object
 func (cmgr clientMgr) ApplyObject(info *resource.Info) error {
-	return cmgr.ApplyObjectInOtherNamespace(info, info.Namespace)
-}
-
-// ApplyObjectInOtherNamespace Takes the definition of an object and applies it in a different ns
-func (cmgr clientMgr) ApplyObjectInOtherNamespace(info *resource.Info, namespace string) error {
-	var metadataAccessor = meta.NewAccessor()
 	helper := resource.NewHelper(info.Client, info.Mapping).
-		WithFieldManager("forgeops")
+		WithFieldManager("forgeops-cli")
 
-	isNamespace := strings.ToLower(info.ResourceMapping().GroupVersionKind.Kind) == "namespace"
-	if namespace != "" {
-		// if the object type is a namespace OR
-		// if the object is a namespaced object and the namespace provided is different, then change the namespace
-		if isNamespace || (info.Namespaced() && info.Namespace != namespace) {
-			if isNamespace {
-				info.Name = namespace
-				if err := metadataAccessor.SetName(info.Object, namespace); err != nil {
-					return err
-				}
-			} else {
-				info.Namespace = namespace
-				if err := metadataAccessor.SetNamespace(info.Object, namespace); err != nil {
-					return err
-				}
-			}
+	// Clear "managedFields" before patching
+	unstructured.RemoveNestedField(info.Object.(*unstructured.Unstructured).Object, "metadata", "managedFields")
+	data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, info.Object)
+	if err != nil {
+		if statusError, ok := err.(apierrors.APIStatus); ok {
+			status := statusError.Status()
+			status.Message = fmt.Sprintf("error when %s %q: %v", "serverside-apply", info.Source, status.Message)
+			return &apierrors.StatusError{ErrStatus: status}
 		}
+		return fmt.Errorf("error when %s %q: %v", "serverside-apply", info.Source, err)
 	}
+
 	// if the object doesn't exist. Create it. Otherwise, patch it.
 	if err := info.Get(); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -164,26 +169,12 @@ func (cmgr clientMgr) ApplyObjectInOtherNamespace(info *resource.Info, namespace
 	}
 	// The object exist. Patch/Apply instead
 	// Send the full object to be applied on the server side.
-	data, err := runtime.Encode(unstructured.UnstructuredJSONScheme, info.Object)
-	if err != nil {
-		if statusError, ok := err.(apierrors.APIStatus); ok {
-			status := statusError.Status()
-			status.Message = fmt.Sprintf("error when %s %q: %v", "serverside-apply", info.Source, status.Message)
-			return &apierrors.StatusError{ErrStatus: status}
-		}
-		return fmt.Errorf("error when %s %q: %v", "serverside-apply", info.Source, err)
-	}
-	options := metav1.PatchOptions{
-		Force: func(b bool) *bool { return &b }(false),
-	}
-	data, err = cmgr.clearManagedFields(data)
-
 	obj, err := helper.Patch(
 		info.Namespace,
 		info.Name,
-		types.ApplyPatchType,
+		types.MergePatchType,
 		data,
-		&options,
+		nil,
 	)
 	if err != nil {
 		return err
@@ -191,36 +182,12 @@ func (cmgr clientMgr) ApplyObjectInOtherNamespace(info *resource.Info, namespace
 	info.Refresh(obj, true)
 	printer.Noticef(fmt.Sprintf("%s %q applied", info.ResourceMapping().GroupVersionKind.Kind, info.Name))
 	return nil
-
 }
 
 func (cmgr clientMgr) DeleteObject(info *resource.Info) error {
-	return cmgr.DeleteObjectFromOtherNamespace(info, info.Namespace)
-}
-
-func (cmgr clientMgr) DeleteObjectFromOtherNamespace(info *resource.Info, namespace string) error {
-	var metadataAccessor = meta.NewAccessor()
 	helper := resource.NewHelper(info.Client, info.Mapping).
-		WithFieldManager("forgeops")
+		WithFieldManager("forgeops-cli")
 
-	isNamespace := strings.ToLower(info.ResourceMapping().GroupVersionKind.Kind) == "namespace"
-	if namespace != "" {
-		// if the object type is a namespace OR
-		// if the object is a namespaced object and the namespace provided is different, then change the namespace
-		if isNamespace || (info.Namespaced() && info.Namespace != namespace) {
-			if isNamespace {
-				info.Name = namespace
-				if err := metadataAccessor.SetName(info.Object, namespace); err != nil {
-					return err
-				}
-			} else {
-				info.Namespace = namespace
-				if err := metadataAccessor.SetNamespace(info.Object, namespace); err != nil {
-					return err
-				}
-			}
-		}
-	}
 	var gracePeriodSeconds int64 = 30
 	propagationPolicy := metav1.DeletePropagationBackground
 	options := metav1.DeleteOptions{
@@ -234,26 +201,4 @@ func (cmgr clientMgr) DeleteObjectFromOtherNamespace(info *resource.Info, namesp
 	info.Refresh(obj, true)
 	printer.Noticef(fmt.Sprintf("%s %q deleted", info.ResourceMapping().GroupVersionKind.Kind, info.Name))
 	return nil
-}
-
-// clearManagedFields removes any entry from metadata.managedFields
-// when using the apply operation you cannot have managedFields in the object that is being applied
-func (cmgr clientMgr) clearManagedFields(data []byte) ([]byte, error) {
-	var err error
-	var raw map[string]json.RawMessage
-	var metadata metav1.ObjectMeta
-
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return []byte{}, err
-	}
-	if err := json.Unmarshal(raw["metadata"], &metadata); err != nil {
-		return []byte{}, err
-	}
-	metadata.SetManagedFields([]metav1.ManagedFieldsEntry{})
-
-	raw["metadata"], err = json.Marshal(metadata)
-	if err != nil {
-		return []byte{}, err
-	}
-	return json.Marshal(raw)
 }

--- a/internal/utils/download.go
+++ b/internal/utils/download.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// DownloadTextFile downloads a file from a given URL or return an error otherwise
+func DownloadTextFile(URL string) (string, error) {
+	//Get the response bytes from the url
+	response, err := http.Get(URL)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != 200 {
+		return "", fmt.Errorf("Received non 200 response code: %d", response.StatusCode)
+	}
+	contents := new(bytes.Buffer)
+	_, err = io.Copy(contents, response.Body)
+	if err != nil {
+		return "", err
+	}
+	return contents.String(), nil
+}

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -2,37 +2,56 @@ package apply
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ForgeRock/forgeops-cli/internal/factory"
 	"github.com/ForgeRock/forgeops-cli/internal/k8s"
+	"github.com/ForgeRock/forgeops-cli/pkg/version"
+	"k8s.io/apimachinery/pkg/api/meta"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/cli-runtime/pkg/resource"
 )
 
-// Manifest Installs the quickstart in the namespace provided
-func Manifest(clientFactory factory.Factory, path string) error {
+// TransformInfoFunc is used to modify the resource.Info
+type TransformInfoFunc func(*resource.Info) error
+
+// Manifest obtains the manifest from the given path or URL and applies it in the namespace provided
+func Manifest(clientFactory factory.Factory, path string, transformFunctions ...TransformInfoFunc) error {
 	k8sCntMgr := k8s.NewK8sClientMgr(clientFactory)
 	infos, err := k8sCntMgr.GetObjectsFromPath(path)
 	if err != nil {
 		return err
 	}
-	return Resources(clientFactory, infos)
+	return Resources(clientFactory, infos, transformFunctions...)
 }
 
-// Resources applies the resources provided
-func Resources(clientFactory factory.Factory, infos []*resource.Info) error {
-	errs := []error{}
+// ManifestStr Applies the given manifest in the namespace provided
+func ManifestStr(clientFactory factory.Factory, manifestContents string, transformFunctions ...TransformInfoFunc) error {
 	k8sCntMgr := k8s.NewK8sClientMgr(clientFactory)
-	cfg, err := k8sCntMgr.GetOverrideFlags()
+	infos, err := k8sCntMgr.GetObjectsFromStream(strings.NewReader(manifestContents))
 	if err != nil {
 		return err
 	}
+	return Resources(clientFactory, infos, transformFunctions...)
+}
+
+// Resources applies the resources provided
+func Resources(clientFactory factory.Factory, infos []*resource.Info, transformFunctions ...TransformInfoFunc) error {
+	errs := []error{}
+	k8sCntMgr := k8s.NewK8sClientMgr(clientFactory)
 	if len(infos) == 0 {
 		return fmt.Errorf("no objects found")
 	}
+	for _, tf := range transformFunctions {
+		for _, info := range infos {
+			if err := tf(info); err != nil {
+				return err
+			}
+		}
+	}
 	// Iterate through all objects, applying each one.
 	for _, info := range infos {
-		if err := k8sCntMgr.ApplyObjectInOtherNamespace(info, *cfg.Namespace); err != nil {
+		if err := k8sCntMgr.ApplyObject(info); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -45,4 +64,25 @@ func Resources(clientFactory factory.Factory, infos []*resource.Info) error {
 		return utilerrors.NewAggregate(errs)
 	}
 	return nil
+}
+
+// Provides a set of standard transforms applied to resource.Info objects
+func standardTransforms() []TransformInfoFunc {
+
+	manageLabels := func(info *resource.Info) error {
+		var metadataAccessor = meta.NewAccessor()
+		labels, err := metadataAccessor.Labels(info.Object)
+		if err != nil {
+			return err
+		}
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels["forgeops-cli.forgerock.com/version"] = version.Version
+		metadataAccessor.SetLabels(info.Object, labels)
+		return nil
+	}
+
+	return []TransformInfoFunc{manageLabels}
+
 }

--- a/pkg/apply/tools.go
+++ b/pkg/apply/tools.go
@@ -17,7 +17,7 @@ func GHResource(clientFactory factory.Factory, ghRepo, fileName, version string)
 		fPath = fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", ghRepo, version, fileName)
 	}
 	printer.Noticef("Installing %q version: %q", ghRepo, version)
-	if err := Manifest(clientFactory, fPath); err != nil {
+	if err := Manifest(clientFactory, fPath, standardTransforms()...); err != nil {
 		return err
 	}
 	printer.Noticef("Installed %q version: %q", ghRepo, version)


### PR DESCRIPTION
1. Simplify clientMgr lib. Add `GetObjectsFromStream` fn
1. Apply/Delete operations download the manifest then find/replace changes
1. Add custom FQDN support to the CDQ deployment
1. Add `--fqdn` flag to `apply quickstart` cmd
1. Updated `pkg.apply` functions to accept transform functions
1. Use transforms to add custom labels to all objects created by the CLI
1. Expanded quickstart config in preparation for a custom config object
1. Updated `--tag` help text

Closes #38
Fixes  #35
Closes #36