### PR TITLE
feat: Add logging and printing configuration and Interface for log me…

### DIFF
--- a/api/forgeops_cli_types.go
+++ b/api/forgeops_cli_types.go
@@ -1,0 +1,55 @@
+package api
+
+import "errors"
+
+// ResultStatus result of a command
+type ResultStatus string
+
+var (
+	// ResultStatusSuccess command completed without errors
+	ResultStatusSuccess ResultStatus = "Success"
+	// ResultStatusFailure command completed with errors
+	ResultStatusFailure ResultStatus = "Failed"
+)
+
+// ResultMessage is amessage that contains a result from the command. The struture is a key value, where value is a string
+type ResultMessage map[string]string
+
+// NewResultFromKeyPair build a result message from key value pairs
+func NewResultFromKeyPair(kp ...string) (*ForgeOpsResult, error) {
+	result := ResultMessage{}
+	// make sure we are given key pairs
+	if len(kp)%2 != 0 {
+		return &ForgeOpsResult{}, errors.New("only keypairs are accepted")
+	}
+	// loop over key pairs by 2
+	for i := 0; i < len(kp); i = i + 2 {
+		result[kp[i]] = kp[i+1]
+	}
+	return &ForgeOpsResult{
+		Results: []ResultMessage{
+			result,
+		},
+		Version: "v1alpha1",
+	}, nil
+}
+
+// ForgeOpsResult structure of a result message
+type ForgeOpsResult struct {
+	// Results are outputs from the given
+	Results []ResultMessage
+	// Status completion status of command
+	Status ResultStatus
+	// Version of this message structure
+	Version string
+}
+
+// Success set the status to succeded
+func (r *ForgeOpsResult) Success() {
+	r.Status = ResultStatusSuccess
+}
+
+// Failed set the status to failed
+func (r *ForgeOpsResult) Failed() {
+	r.Status = ResultStatusFailure
+}

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra/doc"
 )
 
-var output string
+var docFormat string
 var outputDir string
 
 var docsCmd = &cobra.Command{
@@ -16,7 +16,7 @@ var docsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmdTree := cmd.Parent()
 		os.Mkdir(outputDir, 0755)
-		switch output {
+		switch docFormat {
 		case "man":
 			header := &doc.GenManHeader{
 				Title:   "FORGEOPS",
@@ -40,7 +40,7 @@ var docsCmd = &cobra.Command{
 }
 
 func init() {
-	docsCmd.Flags().StringVarP(&output, "output", "o", "md", "output can be md || man")
+	docsCmd.Flags().StringVarP(&docFormat, "doc-type", "t", "md", "output can be md || man")
 	docsCmd.Flags().StringVarP(&outputDir, "output-dir", "d", "./docs", "output path docs")
 	rootCmd.AddCommand(docsCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"fmt"
-
+	"github.com/ForgeRock/forgeops-cli/api"
+	"github.com/ForgeRock/forgeops-cli/internal/printer"
 	"github.com/ForgeRock/forgeops-cli/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -14,12 +14,29 @@ var versionCmd = &cobra.Command{
 	Long: `
     Print the build information.
     Please provide the output of this command when reporting issues.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Build Date:", version.BuildDate)
-		fmt.Println("Git Commit:", version.GitCommit)
-		fmt.Println("Version:", version.Version)
-		fmt.Println("Go Version:", version.GoVersion)
-		fmt.Println("OS / Arch:", version.OsArch)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log := printer.Logger()
+		log.Debug().Msgf("gathering version information without output of %s", printer.CommandOut)
+		switch printer.CommandOut {
+		case printer.OutJson:
+			results, _ := api.NewResultFromKeyPair(
+				"build_date:", version.BuildDate,
+				"git commit:", version.GitCommit,
+				"version:", version.Version,
+				"go_version:", version.GoVersion,
+				"os_arch:", version.OsArch,
+			)
+			printer.JsonResult("forgeops version", results)
+		case printer.OutText:
+			printer.Printf("Build Date: %s", version.BuildDate)
+			printer.Printf("Git Commit: %s", version.GitCommit)
+			printer.Printf("Version: %s", version.Version)
+			printer.Printf("Go Version: %s", version.GoVersion)
+			printer.Printf("OS / Arch: %s", version.OsArch)
+			return nil
+
+		}
+		return nil
 	},
 	SilenceUsage:      true,
 	DisableAutoGenTag: true,

--- a/docs/forgeops.md
+++ b/docs/forgeops.md
@@ -10,7 +10,9 @@ forgeops is a tool for managing ForgeRock Identity Platform deployments
 ### Options
 
 ```
-  -h, --help   help for forgeops
+  -h, --help               help for forgeops
+      --log-level string   (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
+  -o, --output string      (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
 ```
 
 ### SEE ALSO

--- a/docs/forgeops_apply.md
+++ b/docs/forgeops_apply.md
@@ -48,6 +48,13 @@ Apply common platform components
       --username string                Username for basic authentication to the API server
 ```
 
+### Options inherited from parent commands
+
+```
+      --log-level string   (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
+  -o, --output string      (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
+```
+
 ### SEE ALSO
 
 * [forgeops](forgeops.md)	 - forgeops is a tool for managing ForgeRock Identity Platform deployments

--- a/docs/forgeops_apply_apps.md
+++ b/docs/forgeops_apply_apps.md
@@ -42,7 +42,9 @@ forgeops apply apps [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_apply_base.md
+++ b/docs/forgeops_apply_base.md
@@ -43,7 +43,9 @@ forgeops apply base [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_apply_directory.md
+++ b/docs/forgeops_apply_directory.md
@@ -42,7 +42,9 @@ forgeops apply directory [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_apply_ds-operator.md
+++ b/docs/forgeops_apply_ds-operator.md
@@ -42,7 +42,9 @@ forgeops apply ds-operator [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_apply_quickstart.md
+++ b/docs/forgeops_apply_quickstart.md
@@ -49,7 +49,9 @@ forgeops apply quickstart [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_apply_secret-agent.md
+++ b/docs/forgeops_apply_secret-agent.md
@@ -42,7 +42,9 @@ forgeops apply secret-agent [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_clean.md
+++ b/docs/forgeops_clean.md
@@ -35,6 +35,13 @@ forgeops clean [flags]
   -y, --yes                            Do not prompt for confirmation
 ```
 
+### Options inherited from parent commands
+
+```
+      --log-level string   (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
+  -o, --output string      (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
+```
+
 ### SEE ALSO
 
 * [forgeops](forgeops.md)	 - forgeops is a tool for managing ForgeRock Identity Platform deployments

--- a/docs/forgeops_delete.md
+++ b/docs/forgeops_delete.md
@@ -46,6 +46,13 @@ Delete common platform components
   -y, --yes                            Do not prompt for confirmation
 ```
 
+### Options inherited from parent commands
+
+```
+      --log-level string   (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
+  -o, --output string      (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
+```
+
 ### SEE ALSO
 
 * [forgeops](forgeops.md)	 - forgeops is a tool for managing ForgeRock Identity Platform deployments

--- a/docs/forgeops_delete_apps.md
+++ b/docs/forgeops_delete_apps.md
@@ -41,7 +41,9 @@ forgeops delete apps [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_delete_base.md
+++ b/docs/forgeops_delete_base.md
@@ -41,7 +41,9 @@ forgeops delete base [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_delete_directory.md
+++ b/docs/forgeops_delete_directory.md
@@ -41,7 +41,9 @@ forgeops delete directory [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_delete_ds-operator.md
+++ b/docs/forgeops_delete_ds-operator.md
@@ -38,7 +38,9 @@ forgeops delete ds-operator [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_delete_quickstart.md
+++ b/docs/forgeops_delete_quickstart.md
@@ -42,7 +42,9 @@ forgeops delete quickstart [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_delete_secret-agent.md
+++ b/docs/forgeops_delete_secret-agent.md
@@ -38,7 +38,9 @@ forgeops delete secret-agent [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_docs.md
+++ b/docs/forgeops_docs.md
@@ -9,9 +9,16 @@ forgeops docs [flags]
 ### Options
 
 ```
+  -t, --doc-type string     output can be md || man (default "md")
   -h, --help                help for docs
-  -o, --output string       output can be md || man (default "md")
   -d, --output-dir string   output path docs (default "./docs")
+```
+
+### Options inherited from parent commands
+
+```
+      --log-level string   (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
+  -o, --output string      (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
 ```
 
 ### SEE ALSO

--- a/docs/forgeops_doctor.md
+++ b/docs/forgeops_doctor.md
@@ -44,6 +44,13 @@ forgeops doctor [flags]
       --username string                Username for basic authentication to the API server
 ```
 
+### Options inherited from parent commands
+
+```
+      --log-level string   (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
+  -o, --output string      (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
+```
+
 ### SEE ALSO
 
 * [forgeops](forgeops.md)	 - forgeops is a tool for managing ForgeRock Identity Platform deployments

--- a/docs/forgeops_doctor_operators.md
+++ b/docs/forgeops_doctor_operators.md
@@ -42,7 +42,9 @@ forgeops doctor operators [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_doctor_platform.md
+++ b/docs/forgeops_doctor_platform.md
@@ -41,7 +41,9 @@ forgeops doctor platform [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_status.md
+++ b/docs/forgeops_status.md
@@ -44,6 +44,13 @@ forgeops status [flags]
       --username string                Username for basic authentication to the API server
 ```
 
+### Options inherited from parent commands
+
+```
+      --log-level string   (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
+  -o, --output string      (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
+```
+
 ### SEE ALSO
 
 * [forgeops](forgeops.md)	 - forgeops is a tool for managing ForgeRock Identity Platform deployments

--- a/docs/forgeops_status_operators.md
+++ b/docs/forgeops_status_operators.md
@@ -42,7 +42,9 @@ forgeops status operators [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_status_platform.md
+++ b/docs/forgeops_status_platform.md
@@ -41,7 +41,9 @@ forgeops status platform [flags]
       --context string                 The name of the kubeconfig context to use
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
   -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
       --password string                Password for basic authentication to the API server
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server

--- a/docs/forgeops_version.md
+++ b/docs/forgeops_version.md
@@ -18,6 +18,13 @@ forgeops version [flags]
   -h, --help   help for version
 ```
 
+### Options inherited from parent commands
+
+```
+      --log-level string   (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
+  -o, --output string      (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
+```
+
 ### SEE ALSO
 
 * [forgeops](forgeops.md)	 - forgeops is a tool for managing ForgeRock Identity Platform deployments

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/rs/zerolog v1.20.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -349,6 +349,9 @@ github.com/rivo/tview v0.0.0-20200219210816-cd38d7432498/go.mod h1:6lkG1x+13OShE
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.20.0 h1:38k9hgtUBdxFwE34yS8rTHmHBa4eN16E4DJlv177LNs=
+github.com/rs/zerolog v1.20.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -557,6 +560,7 @@ golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -2,8 +2,15 @@ package printer
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"time"
 
 	"github.com/fatih/color"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/ForgeRock/forgeops-cli/api"
 )
 
 var (
@@ -11,7 +18,7 @@ var (
 	infoStr             = "✔  INFO:"
 	warnStr             = "❗ WARN:"
 	errStr              = "✗  ERROR:"
-	fmtStr              = "%s %s\n"
+	fmtStr              = "%s %s"
 	regColorPrefix      = color.New(color.Bold, color.FgWhite).SprintFunc()
 	regColorMsg         = color.New(color.FgWhite).SprintFunc()
 	noticeColorPrefix   = color.New(color.Bold, color.FgCyan).SprintFunc()
@@ -22,59 +29,146 @@ var (
 	errorColorMsg       = color.New(color.FgRed).SprintFunc()
 	warnColorPrefix     = color.New(color.Bold, color.FgYellow).SprintFunc()
 	warnColorMsg        = color.New(color.FgYellow).SprintFunc()
+	console             = log.Logger
+	cmdResultOut        = log.Logger
+	logn                = log.Logger
+)
+
+// OutType determine if we should be logging with text or json
+type OutType string
+
+var (
+	// OutText output as text
+	OutText OutType = "Text"
+	// OutJson output as json
+	OutJson OutType = "Json"
+	// CommandOut output config setting
+	CommandOut OutType = OutText
 )
 
 // Printf print an informational message
 func Printf(s string, args ...interface{}) {
 	out := fmt.Sprintf(s, args...)
-	fmt.Printf(fmtStr, regColorPrefix(regStr), regColorMsg(out))
+	console.Printf(fmtStr, regColorPrefix(regStr), regColorMsg(out))
 }
 
 // Println print an informational message
 func Println(s string) {
-	fmt.Printf(fmtStr, regColorPrefix(regStr), regColorMsg(s))
+	console.Printf(fmtStr, regColorPrefix(regStr), regColorMsg(s))
 }
 
-// Noticef print an informational message
+// Noticef print a notice message
 func Noticef(s string, args ...interface{}) {
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	out := fmt.Sprintf(s, args...)
-	fmt.Printf(fmtStr, noticeColorPrefix(infoStr), noticeColorMsg(out))
+	console.Printf(fmtStr, noticeColorPrefix(infoStr), noticeColorMsg(out))
 }
 
-// Noticeln print an informational message
+// Noticeln print a notice message
 func Noticeln(s string) {
-	fmt.Printf(fmtStr, noticeColorPrefix(infoStr), noticeColorMsg(s))
+	console.Printf(fmtStr, noticeColorPrefix(infoStr), noticeColorMsg(s))
 }
 
-// NoticeHif print an informational message
+// NoticeHif print a notice message
 func NoticeHif(s string, args ...interface{}) {
 	out := fmt.Sprintf(s, args...)
-	fmt.Printf(fmtStr, noticeHiColorPrefix(infoStr), noticeHiColorMsg(out))
+	console.Printf(fmtStr, noticeHiColorPrefix(infoStr), noticeHiColorMsg(out))
 }
 
-// NoticeHiln print an informational message
+// NoticeHiln print a notice message
 func NoticeHiln(s string) {
-	fmt.Printf(fmtStr, noticeHiColorPrefix(infoStr), noticeHiColorMsg(s))
+	console.Printf(fmtStr, noticeHiColorPrefix(infoStr), noticeHiColorMsg(s))
 }
 
-// Warnf print an informational message
+// Warnf print a warning message
 func Warnf(s string, args ...interface{}) {
 	out := fmt.Sprintf(s, args...)
-	fmt.Printf(fmtStr, warnColorPrefix(warnStr), warnColorMsg(out))
+	console.Printf(fmtStr, warnColorPrefix(warnStr), warnColorMsg(out))
 }
 
 // Warnln print an informational message
 func Warnln(s string) {
-	fmt.Printf(fmtStr, warnColorPrefix(warnStr), warnColorMsg(s))
+	console.Printf(fmtStr, warnColorPrefix(warnStr), warnColorMsg(s))
 }
 
-// Errorf print an informational message
+// Errorf print an error message
 func Errorf(s string, args ...interface{}) {
 	out := fmt.Sprintf(s, args...)
-	fmt.Printf(fmtStr, errorColorPrefix(errStr), errorColorMsg(out))
+	console.Printf(fmtStr, errorColorPrefix(errStr), errorColorMsg(out))
 }
 
-// Errorln print an informational message
+// Errorln print an error message
 func Errorln(s string) {
-	fmt.Printf(fmtStr, errorColorPrefix(errStr), errorColorMsg(s))
+	console.Printf(fmtStr, errorColorPrefix(errStr), errorColorMsg(s))
+}
+
+// JsonResult provide a message that contains api.ForgeOpsResult
+// This logger is configured to ignore log levels set by a user because it's the
+// "return value" for a commmand. This is the output method to be used for scripting interfaces
+func JsonResult(msg string, res *api.ForgeOpsResult) {
+	eventResult := zerolog.Dict()
+	for _, msg := range res.Results {
+		for k, v := range msg {
+			eventResult.Str(k, v)
+		}
+	}
+	cmdResultOut.Info().
+		Str("version", res.Version).
+		Str("status", string(res.Status)).
+		Dict("results", eventResult).Msg(msg)
+}
+
+// Logger global main logger that should be used to log errors, debug etc
+func Logger() zerolog.Logger {
+	return logn
+}
+
+// InitLogn configures main logger for program..
+// logn with "text" mode is always debug level due to zerolog
+func InitLogn(logType OutType, l zerolog.Level) {
+	if l == zerolog.Disabled {
+		logn = zerolog.Nop()
+		CommandOut = logType
+		return
+	}
+	switch logType {
+	case OutText:
+		CommandOut = OutText
+		consolen := zerolog.ConsoleWriter{Out: os.Stdout}
+		logn = zerolog.New(consolen).With().Timestamp().Logger()
+	case OutJson:
+		CommandOut = OutJson
+		logn = zerolog.New(os.Stdout).With().Timestamp().Logger()
+	}
+	logn.Level(l)
+}
+
+func init() {
+	// Global logging config
+	zerolog.TimeFieldFormat = time.RFC3339
+
+	// Setup logging to console
+	consoleOutput := zerolog.ConsoleWriter{Out: os.Stdout}
+	consoleOutput.FormatLevel = func(i interface{}) string {
+		return ""
+	}
+	consoleOutput.FormatMessage = func(i interface{}) string {
+		return fmt.Sprintf("%s", i)
+	}
+	consoleOutput.FormatFieldName = func(i interface{}) string {
+		return fmt.Sprintf("%s:", i)
+	}
+	consoleOutput.FormatFieldValue = func(i interface{}) string {
+		return strings.ToUpper(fmt.Sprintf("%s", i))
+	}
+	consoleOutput.PartsOrder = []string{
+		zerolog.MessageFieldName,
+	}
+	console = zerolog.New(consoleOutput)
+
+	// Setup a command result log, this should be used to log the result of a command
+	cmdResultOut = zerolog.New(os.Stdout).
+		With().
+		Timestamp().
+		Logger()
 }


### PR DESCRIPTION
…ssages

This moves printing to using a logging package. The printer package and
root command now configure 3 separate logging instances.
1) a logger that's intended to be used for human interfaces and works
   just like the initial printer package. This is for printing things in
   the "doctor" command or anywhere it's a human command. This works
2) JsonResult is a method to return a JsonResult from a command this can
   be used by any command that provides a api interface
3) printer.Logger() which returns a logger that is configured from cli
   options. This is the logger that should be used in the program for
   debugging etc. e.g. `log.Msg("gathering version information")` This
   logger should be used to log anything needed in any command. The user
   can set the level of the output and may also set it to be "text"
   output which is always "debug" level

printer module now has a variable CommandOut that is initialize as the
--output flag value. This is to allow commands to switch on output types
should they need to. e.g. "version"

This introduces the api package, with a ForgeOpsResult type which is a
versioned object intended to provide a stable programmable interface for
script users.

ref: CLOUD-2892

![image](https://user-images.githubusercontent.com/55297723/108563215-f16c8480-72b5-11eb-80ce-03805a661dbd.png)
