### PR TITLE
Add "forgeops get" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ IMAGE_NAME := "forgerock/forgeops-cli"
 
 PR_VERSION_NAME = ${VERSION}-pr.${PR_NUMBER}
 
-all: build docs
+all: test build docs
 
 pr-tag:
 	git tag "$(PR_VERSION_NAME)"

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -169,6 +169,7 @@ var applyCmd = &cobra.Command{
     forgeops apply quickstart --tag 2020.10.28-AlSugoDiNoci --namespace mynamespace --fqdn demo.customdomain.com`,
 	// Configure Client Mgr for all subcommands
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		cmd.Parent().PersistentPreRun(cmd.Parent(), args)
 		clientFactory = factory.NewFactory(applyFlags)
 	},
 	SilenceUsage:      true,

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -18,6 +18,7 @@ var cleanCmd = &cobra.Command{
     Remove any remaining platform components from the given namespace`,
 	// Configure Client Mgr for all subcommands
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		cmd.Parent().PersistentPreRun(cmd.Parent(), args)
 		clientFactory = factory.NewFactory(cleanFlags)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -147,6 +147,7 @@ var deleteCmd = &cobra.Command{
     forgeops delete secret-agent`,
 	// Configure Client Mgr for all subcommands
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		cmd.Parent().PersistentPreRun(cmd.Parent(), args)
 		clientFactory = factory.NewFactory(deleteFlags)
 	},
 	SilenceUsage:      true,

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -119,6 +119,7 @@ var (
 		`,
 		// Configure Client Mgr for all subcommands
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cmd.Parent().PersistentPreRun(cmd.Parent(), args)
 			clientFactory = factory.NewFactory(doctorFlags)
 
 		},

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"github.com/ForgeRock/forgeops-cli/internal/factory"
+	"github.com/ForgeRock/forgeops-cli/pkg/get"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// cmd globals config
+var getFlags *genericclioptions.ConfigFlags
+
+var getSecrets = &cobra.Command{
+	Use:     "secrets",
+	Aliases: []string{"secret"},
+	Short:   "Get the relevant ForgeRock Identity Platform secrets",
+	Long: `
+    Get the relevant ForgeRock Identity Platform secrets:
+    * Reads secrets from the Kubernetes API
+    * Returns json format or prints them in the console`,
+	Example: `
+    # Get the platform secrets from the default namespace in text format.
+    forgeops get secrets
+    
+    # Get the secrets from the given namespace in json format.
+    forgeops get secrets -o json -n myns`,
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := get.Secrets(clientFactory)
+		return err
+	},
+	SilenceUsage:      true,
+	DisableAutoGenTag: true,
+}
+
+var getURLs = &cobra.Command{
+	Use:     "urls",
+	Aliases: []string{"url"},
+	Short:   "Get the relevant ForgeRock Identity Platform URLs",
+	Long: `
+    Get the relevant ForgeRock Identity Platform URLs:
+    * Obtains the FQDN from the "forgerock" ingress in the Kubernetes
+    * Prints out the URLs in the console`,
+	Example: `
+    # Get the platform URLs from the default namespace in text format.
+    forgeops get urls`,
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := get.URLs(clientFactory, "forgerock")
+		return err
+	},
+	SilenceUsage:      true,
+	DisableAutoGenTag: true,
+}
+
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get platform information",
+	Long: `
+    Get relevant ForgeRock Identity Platform information`,
+	Example: `
+    # Get platform secrets from the default namespace.
+    forgeops get secrets`,
+
+	// Configure Client Mgr for all subcommands
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		cmd.Parent().PersistentPreRun(cmd.Parent(), args)
+		clientFactory = factory.NewFactory(getFlags)
+	},
+	SilenceUsage:      true,
+	DisableAutoGenTag: true,
+}
+
+func init() {
+	// Install k8s flags
+	getFlags = initK8sFlags(getCmd.PersistentFlags())
+
+	getCmd.AddCommand(getSecrets)
+	getCmd.AddCommand(getURLs)
+
+	rootCmd.AddCommand(getCmd)
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -117,6 +117,7 @@ var (
 		`,
 		// Configure Client Mgr for all subcommands
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cmd.Parent().PersistentPreRun(cmd.Parent(), args)
 			clientFactory = factory.NewFactory(doctorFlags)
 
 		},

--- a/docs/forgeops.md
+++ b/docs/forgeops.md
@@ -22,6 +22,7 @@ forgeops is a tool for managing ForgeRock Identity Platform deployments
 * [forgeops delete](forgeops_delete.md)	 - Delete common platform components
 * [forgeops docs](forgeops_docs.md)	 - Generate docs
 * [forgeops doctor](forgeops_doctor.md)	 - Diagnose common cluster and platform deployments
+* [forgeops get](forgeops_get.md)	 - Get platform information
 * [forgeops status](forgeops_status.md)	 - Diagnose common cluster and platform deployments
 * [forgeops version](forgeops_version.md)	 - Print the build information
 

--- a/docs/forgeops_get.md
+++ b/docs/forgeops_get.md
@@ -1,0 +1,53 @@
+## forgeops get
+
+Get platform information
+
+### Synopsis
+
+
+    Get relevant ForgeRock Identity Platform information
+
+### Examples
+
+```
+
+    # Get platform secrets from the default namespace.
+    forgeops get secrets
+```
+
+### Options
+
+```
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+  -h, --help                           help for get
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --password string                Password for basic authentication to the API server
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+      --username string                Username for basic authentication to the API server
+```
+
+### Options inherited from parent commands
+
+```
+      --log-level string   (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
+  -o, --output string      (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
+```
+
+### SEE ALSO
+
+* [forgeops](forgeops.md)	 - forgeops is a tool for managing ForgeRock Identity Platform deployments
+* [forgeops get secrets](forgeops_get_secrets.md)	 - Get the relevant ForgeRock Identity Platform secrets
+* [forgeops get urls](forgeops_get_urls.md)	 - Get the relevant ForgeRock Identity Platform URLs
+

--- a/docs/forgeops_get_secrets.md
+++ b/docs/forgeops_get_secrets.md
@@ -1,0 +1,60 @@
+## forgeops get secrets
+
+Get the relevant ForgeRock Identity Platform secrets
+
+### Synopsis
+
+
+    Get the relevant ForgeRock Identity Platform secrets:
+    * Reads secrets from the Kubernetes API
+    * Returns json format or prints them in the console
+
+```
+forgeops get secrets [flags]
+```
+
+### Examples
+
+```
+
+    # Get the platform secrets from the default namespace in text format.
+    forgeops get secrets
+    
+    # Get the secrets from the given namespace in json format.
+    forgeops get secrets -o json -n myns
+```
+
+### Options
+
+```
+  -h, --help   help for secrets
+```
+
+### Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
+      --password string                Password for basic authentication to the API server
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+      --username string                Username for basic authentication to the API server
+```
+
+### SEE ALSO
+
+* [forgeops get](forgeops_get.md)	 - Get platform information
+

--- a/docs/forgeops_get_urls.md
+++ b/docs/forgeops_get_urls.md
@@ -1,0 +1,57 @@
+## forgeops get urls
+
+Get the relevant ForgeRock Identity Platform URLs
+
+### Synopsis
+
+
+    Get the relevant ForgeRock Identity Platform URLs:
+    * Obtains the FQDN from the "forgerock" ingress in the Kubernetes
+    * Prints out the URLs in the console
+
+```
+forgeops get urls [flags]
+```
+
+### Examples
+
+```
+
+    # Get the platform URLs from the default namespace in text format.
+    forgeops get urls
+```
+
+### Options
+
+```
+  -h, --help   help for urls
+```
+
+### Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --log-level string               (options: none|debug|info|warn|error) log statement level. When output=text and level is not 'none' the level is debug (default "none")
+  -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output string                  (options: text|json) command output type. Type json is intended for use in scripting, text is for interactive usage. Not all commands provide both types of output (default "text")
+      --password string                Password for basic authentication to the API server
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+      --username string                Username for basic authentication to the API server
+```
+
+### SEE ALSO
+
+* [forgeops get](forgeops_get.md)	 - Get platform information
+

--- a/pkg/get/secrets.go
+++ b/pkg/get/secrets.go
@@ -1,0 +1,142 @@
+package get
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ForgeRock/forgeops-cli/api"
+	"github.com/ForgeRock/forgeops-cli/internal/factory"
+	"github.com/ForgeRock/forgeops-cli/internal/k8s"
+	"github.com/ForgeRock/forgeops-cli/internal/printer"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+type qsSecret struct {
+	secretName string
+	keyName    []string
+	printName  []string
+}
+
+type qsConfig struct {
+	placeholderFQDN      string
+	placeholderNamespace string
+	importantSecrets     []qsSecret
+}
+
+// Secrets returns relevant secrets
+func Secrets(clientFactory factory.Factory) error {
+	// TODO: We should obtain settings like these from a config that can be ingested at runtime.
+	// Storing these here for now until we have a solution
+	// https://github.com/ForgeRock/forgeops-cli/issues/58
+	config := qsConfig{
+		importantSecrets: []qsSecret{
+			{
+				secretName: "am-env-secrets",
+				keyName:    []string{"AM_PASSWORDS_AMADMIN_CLEAR"},
+				printName:  []string{"amadmin user"},
+			},
+			{
+				secretName: "ds-passwords",
+				keyName:    []string{"dirmanager.pw"},
+				printName:  []string{"uid=admin user"},
+			},
+			{
+				secretName: "rcs-agent-env-secrets",
+				keyName:    []string{"AGENT_IDM_SECRET", "AGENT_RCS_SECRET"},
+				printName:  []string{"rcs-agent IDM secret", "rcs-agent RCS secret"},
+			},
+		},
+	}
+	return printSecret(clientFactory, config.importantSecrets)
+}
+
+func printSecret(clientFactory factory.Factory, importantSecrets []qsSecret) error {
+	ctx := context.Background()
+	k8sCntMgr := k8s.NewK8sClientMgr(clientFactory)
+	ns, err := k8sCntMgr.Namespace()
+	if err != nil {
+		return err
+	}
+	secretKeyPair := []string{}
+	errs := []error{}
+	sclient, err := k8sCntMgr.Factory().StaticClient()
+	if err != nil {
+		return err
+	}
+	if printer.CommandOut == printer.OutText {
+		printer.Noticef("Relevant passwords:")
+	}
+	for _, s := range importantSecrets {
+		k8sSecret, err := sclient.CoreV1().Secrets(ns).Get(ctx, s.secretName, metav1.GetOptions{})
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		for idx, key := range s.keyName {
+			switch printer.CommandOut {
+			case printer.OutJson:
+				secretKeyPair = append(secretKeyPair, strings.ReplaceAll(s.printName[idx], " ", "_"))
+				secretKeyPair = append(secretKeyPair, string(k8sSecret.Data[key]))
+			case printer.OutText:
+				printer.NoticeHiln(fmt.Sprintf("%s (%s)", string(k8sSecret.Data[key]), s.printName[idx]))
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return utilerrors.NewAggregate(errs)
+	}
+	if printer.CommandOut == printer.OutJson {
+		results, _ := api.NewResultFromKeyPair(secretKeyPair...)
+		printer.JsonResult("forgeops secrets", results)
+	}
+	return nil
+}
+
+// URLs returns releval URLs
+func URLs(clientFactory factory.Factory, platformIngressName string) error {
+	ctx := context.Background()
+	k8sCntMgr := k8s.NewK8sClientMgr(clientFactory)
+	ns, err := k8sCntMgr.Namespace()
+	if err != nil {
+		return err
+	}
+	sclient, err := k8sCntMgr.Factory().StaticClient()
+	if err != nil {
+		return err
+	}
+
+	forgeopsIngress, err := sclient.ExtensionsV1beta1().Ingresses(ns).Get(ctx, platformIngressName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	fqdn := ""
+	for ruleIdx, rule := range forgeopsIngress.Spec.Rules {
+		for _, path := range rule.HTTP.Paths {
+			if path.Backend.ServiceName == "am" {
+				fqdn = forgeopsIngress.Spec.Rules[ruleIdx].Host
+				break
+			}
+		}
+		if len(fqdn) > 0 {
+			break
+		}
+	}
+	if len(fqdn) == 0 {
+		return fmt.Errorf("Could not find the \"am\" rule in the \"%s\" ingress. Review ingress rules", platformIngressName)
+	}
+	printURLs(fqdn)
+	return nil
+}
+
+func printURLs(fqdn string) error {
+	baseURL := fmt.Sprintf("https://%s/", fqdn)
+	printer.Noticef("Relevant URLs:")
+	printer.NoticeHif(baseURL + "platform")
+	printer.NoticeHif(baseURL + "admin")
+	printer.NoticeHif(baseURL + "am")
+	printer.NoticeHif(baseURL + "enduser")
+	return nil
+
+}


### PR DESCRIPTION
Add forgeops get command

1. Add forgeops get command
1. Add forgeops get secrets
command
1. Add forgeops get urls command
1. Fix bug: `PersistentPreRun` is only inherited if not defined in the children. Manually call `rootCmd`s `PersistentPreRun`

Closes: #60
Closes: #47

Sample output: 
```bash
./bin/forgeops get urls -n smoke
✔  INFO: Relevant URLs:
✔  INFO: https://smoke.iam.forgeops.com/platform
✔  INFO: https://smoke.iam.forgeops.com/admin
✔  INFO: https://smoke.iam.forgeops.com/am
✔  INFO: https://smoke.iam.forgeops.com/enduser

```
```bash

./bin/forgeops get secrets -n smoke --output json | jq
{
  "level": "info",
  "version": "v1alpha1",
  "status": "",
  "results": {
    "amadmin_user": "i3Dqp3edJkp6ggkQOGCxSNa8",
    "uid=admin_user": "cbNL8WzWhhy9U5R24Md6Nk1zYSNXatE8",
    "rcs-agent_IDM_secret": "plEc1jRY2zzIDLJ6sRE9ABagjZLMoPsC",
    "rcs-agent_RCS_secret": "hhZJpm844FOMS67RzTjtBdfvoca5gh2w"
  },
  "time": "2021-03-02T20:58:53-08:00",
  "message": "forgeops secrets"
}
```

```bash
amadmin=$(./bin/forgeops get secrets -n smoke --output json | jq -r '.results.amadmin_user')
echo $amadmin
i3Dqp3edJkp6ggkQOGCxSNa8`
```

```bash
./bin/forgeops get secrets -n smoke 
✔  INFO: Relevant passwords:
✔  INFO: i3Dqp3edJkp6ggkQOGCxSNa8 (amadmin user)
✔  INFO: cbNL8WzWhhy9U5R24Md6Nk1zYSNXatE8 (uid=admin user)
✔  INFO: plEc1jRY2zzIDLJ6sRE9ABagjZLMoPsC (rcs-agent IDM secret)
✔  INFO: hhZJpm844FOMS67RzTjtBdfvoca5gh2w (rcs-agent RCS secret)
```


